### PR TITLE
Fix Chromium service worker startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motrix/extension",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Motrix browser extension (Chrome MV3 + Firefox MV3)",
   "type": "module",

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -12,6 +12,7 @@ const sessionStorageState = new Map<string, unknown>()
 // these per-test when they need fuller behavior.
 const chromeStub = {
   runtime: {
+    id: 'test-extension-id',
     connectNative: vi.fn(),
     openOptionsPage: vi.fn(async () => undefined),
     // `computeVerifiedOrigin` (mbp1/verified-origin.ts) calls this on every

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -7,9 +7,8 @@ import youtubeSnifferScriptPath from 'virtual:motrix-youtube-sniffer-script'
 // "No runtime abstraction layer installed". The `/browser` entry re-exports the
 // full public API, so this also provides `Methods`.
 import { Methods } from '@motrix/mdxp/browser'
-// Chromium only exposes `chrome`; use the polyfill object to hoist `browser`
-// before any service-worker startup code reads it. Firefox already provides it.
-import browserPolyfill from 'webextension-polyfill'
+// Install `browser.*` before any shared dependency evaluates in Chromium.
+import '@/shared/browser'
 import { BgAdapterRegistry } from '@/background/AdapterRegistry'
 import { BackendOperationCoordinator } from '@/background/BackendOperationCoordinator'
 import {
@@ -83,9 +82,6 @@ import {
 import { initI18n } from '@/shared/i18n'
 import { isResolvableVideoPage, shouldExcludeHost } from '@/shared/media'
 import { MEDIA_SUBMIT_ERROR } from '@/shared/messages'
-
-const extensionGlobals = globalThis as unknown as { browser?: unknown }
-extensionGlobals.browser ??= browserPolyfill
 
 // Build-time constant injected by vite (see vite.config.ts `define`).
 declare const __BROWSER__: 'chromium' | 'firefox'

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,6 +1,5 @@
-// MUST be first: the polyfill makes `browser.*` available in Chromium.
-import browserPolyfill from 'webextension-polyfill'
-;(globalThis as unknown as { browser?: unknown }).browser ??= browserPolyfill
+// MUST be first: the shared bootstrap makes `browser.*` available in Chromium.
+import '@/shared/browser'
 
 import { ContentRuntime } from '@/content/ContentRuntime'
 

--- a/src/shared/__tests__/chromiumStartup.test.ts
+++ b/src/shared/__tests__/chromiumStartup.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const globals = globalThis as unknown as {
+  browser?: typeof chrome
+}
+const originalBrowser = globals.browser
+
+afterEach(() => {
+  globals.browser = originalBrowser
+  vi.resetModules()
+})
+
+describe('Chromium startup', () => {
+  it('initializes shared modules when Chromium only provides chrome.*', async () => {
+    Reflect.deleteProperty(globals, 'browser')
+    vi.resetModules()
+
+    const { resolveDefaultLocale } = await import('@/shared/i18n')
+
+    expect(globals.browser).toBeDefined()
+    expect(resolveDefaultLocale()).toBe('en-US')
+  })
+})

--- a/src/shared/browser.ts
+++ b/src/shared/browser.ts
@@ -1,0 +1,12 @@
+import browserPolyfill from 'webextension-polyfill'
+
+// Chromium exposes `chrome.*`, while Firefox exposes `browser.*` natively.
+// Install the promise-based polyfill before any shared module reads the
+// ambient `browser` global during module evaluation.
+const extensionGlobals = globalThis as unknown as {
+  browser?: typeof browserPolyfill
+}
+
+extensionGlobals.browser ??= browserPolyfill
+
+export const extensionBrowser = extensionGlobals.browser

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1,5 +1,6 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import { extensionBrowser } from '@/shared/browser'
 import { getLocaleOverride, type SupportedLocale } from '@/shared/localeStore'
 import enUS from '@/shared/locales/en-US.json'
 import zhCN from '@/shared/locales/zh-CN.json'
@@ -10,7 +11,7 @@ const resources = {
 }
 
 export function resolveDefaultLocale(): SupportedLocale {
-  const ui = browser.i18n.getUILanguage().toLowerCase()
+  const ui = extensionBrowser.i18n.getUILanguage().toLowerCase()
   return ui.startsWith('zh') ? 'zh-CN' : 'en-US'
 }
 

--- a/src/shared/localeStore.ts
+++ b/src/shared/localeStore.ts
@@ -1,9 +1,11 @@
+import { extensionBrowser } from '@/shared/browser'
+
 const LOCALE_KEY = 'motrix.locale'
 
 export type SupportedLocale = 'en-US' | 'zh-CN'
 
 export async function getLocaleOverride(): Promise<SupportedLocale | null> {
-  const got = await browser.storage.local.get(LOCALE_KEY)
+  const got = await extensionBrowser.storage.local.get(LOCALE_KEY)
   const v = got[LOCALE_KEY]
   return v === 'en-US' || v === 'zh-CN' ? v : null
 }
@@ -12,9 +14,9 @@ export async function setLocaleOverride(
   v: SupportedLocale | null
 ): Promise<void> {
   if (v === null) {
-    await browser.storage.local.remove(LOCALE_KEY)
+    await extensionBrowser.storage.local.remove(LOCALE_KEY)
   } else {
-    await browser.storage.local.set({ [LOCALE_KEY]: v })
+    await extensionBrowser.storage.local.set({ [LOCALE_KEY]: v })
   }
 }
 

--- a/src/shared/platformCapabilities.ts
+++ b/src/shared/platformCapabilities.ts
@@ -1,8 +1,4 @@
-interface BrowserWithOptionalNativeMessaging {
-  runtime?: {
-    connectNative?: unknown
-  }
-}
+import { extensionBrowser } from '@/shared/browser'
 
 /**
  * Native Messaging is available in desktop Firefox and Chromium browsers,
@@ -10,10 +6,5 @@ interface BrowserWithOptionalNativeMessaging {
  * connections do not depend on it and remain supported on Android.
  */
 export function hasNativeMessagingSupport(): boolean {
-  const extensionBrowser = (
-    globalThis as typeof globalThis & {
-      browser?: BrowserWithOptionalNativeMessaging
-    }
-  ).browser
-  return typeof extensionBrowser?.runtime?.connectNative === 'function'
+  return typeof extensionBrowser.runtime?.connectNative === 'function'
 }


### PR DESCRIPTION
## Summary

- install the WebExtension browser polyfill before shared modules evaluate
- use the initialized browser API for locale and platform capability access
- add a Chromium-only startup regression test
- bump the extension version to 0.1.3

## Verification

- 145 test files and 1908 tests passed
- type checking, formatting, lint, and import checks passed
- Chromium, Chrome/Edge Web Store, and Firefox builds passed
- the emitted Web Store shared chunk loads with chrome available and browser initially absent

Closes #1