### PR TITLE
fix: restore Firefox local pairing

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -84,6 +84,15 @@ export default defineManifest((env) => {
       : { service_worker: 'src/background/service-worker.ts', type: 'module' },
     ...(firefox
       ? {
+          // Firefox's default Manifest V3 CSP includes
+          // `upgrade-insecure-requests`, which rewrites the loopback MBP1
+          // transport from ws:// to wss://. Motrix deliberately serves the
+          // local bridge over plain WebSocket because MBP1 authenticates and
+          // encrypts the session itself, so keep the extension policy strict
+          // while explicitly opting out of that scheme rewrite.
+          content_security_policy: {
+            extension_pages: "script-src 'self'; object-src 'self';",
+          },
           browser_specific_settings: {
             gecko: {
               id: 'motrix-extension@motrix.app',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motrix/extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Motrix browser extension (Chrome MV3 + Firefox MV3)",
   "type": "module",

--- a/src/__tests__/manifest-csp.test.ts
+++ b/src/__tests__/manifest-csp.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import manifestConfig from '#manifest-config'
+
+type GeneratedManifest = {
+  content_security_policy?: {
+    extension_pages?: string
+  }
+}
+
+async function manifestFor(mode: string): Promise<GeneratedManifest> {
+  return (await manifestConfig({ command: 'build', mode })) as GeneratedManifest
+}
+
+describe('extension page content security policy', () => {
+  it('keeps Firefox loopback WebSockets from being upgraded to WSS', async () => {
+    const manifest = await manifestFor('firefox')
+    const policy = manifest.content_security_policy?.extension_pages
+
+    expect(policy).toBe("script-src 'self'; object-src 'self';")
+    expect(policy).not.toContain('upgrade-insecure-requests')
+  })
+
+  it('leaves Chromium on its browser-provided default policy', async () => {
+    const manifest = await manifestFor('chromium')
+
+    expect(manifest.content_security_policy).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- override Firefox's default Manifest V3 CSP without `upgrade-insecure-requests`
- preserve the local MBP1 `ws://127.0.0.1` pairing transport
- add manifest regression coverage and prepare version 0.1.4

## Verification

- TypeScript typecheck
- Biome and import-boundary checks
- 145 test files / 1905 tests
- Chrome/Edge Web Store build verification
- Firefox build verification
- release version verification for 0.1.4

Fixes agalwood/Motrix#2042