### PR TITLE
docs(ext): link published browser stores and clarify development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Send downloads from your browser to [Motrix](https://motrix.app), then check the
 I think of it as a bridge between the browser and Motrix. The browser is good at finding resources; Motrix is good at downloading them reliably. That division of labor is simple, and it feels right in daily use.
 
 > [!IMPORTANT]
-> `v0.1.2` is still in development and has not been released publicly. It is not ready to be your everyday download tool. YouTube support, in particular, is only placeholder code for integration testing and cannot perform a real download. Store-facing Chrome/Edge and Firefox builds remove that code entirely.
+> Motrix Extension is available from the Chrome Web Store and Microsoft Edge Add-ons. YouTube downloads are not supported; store-facing Chrome/Edge and Firefox builds remove the placeholder YouTube adapter entirely.
 
 ## What you can do
 
@@ -24,14 +24,27 @@ This is useful, but websites are messy. Login state, expiring URLs, hotlink prot
 
 You will need:
 
-- Chrome 120 or later, or Firefox 142 or later;
+- Chrome 120 or later, a current Microsoft Edge release, or Firefox 142 or later;
 - a Motrix App or Motrix Server compatible with the current MDXP / MBP1 protocol;
 - for a local connection, a running Motrix App with its browser integration component installed correctly.
 
 Firefox for Android connects through Motrix Server. Native Messaging is not
 available there, so the local Motrix App backend is shown only on desktop.
 
-There is no store release or stable installer yet. Early testing requires a source build. If you simply want a quiet, dependable download tool, I would wait for the first public release. It will save you a fair amount of friction.
+## Install
+
+Install [Motrix 2](https://motrix.app/download?channel=beta), then add the extension from your browser's store:
+
+- [Chrome Web Store](https://chromewebstore.google.com/detail/motrix-extension/lggbokfckofcgjndaboioakcmincinpo)
+- [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/motrix-extension/efcflljngohddnmfmebiamigoikmdfbf)
+
+Store installations do not require Developer mode or a manually added trusted extension ID. Follow [Connect for the first time](#connect-for-the-first-time) below to pair with Motrix, or read the [browser extension guide](https://motrix.app/manual/browser-extension/).
+
+Local browser integration is not currently available in the Motrix AppImage package. On Linux, use the DEB or RPM package for local pairing.
+
+The Firefox store release is coming soon. Use the development workflow below to build and temporarily load it.
+
+## Manual browser workflow (development)
 
 <details>
 <summary>Install a test build from source</summary>
@@ -44,16 +57,16 @@ pnpm build:chromium
 pnpm build:firefox
 ```
 
-Chrome: open `chrome://extensions`, enable **Developer mode**, choose **Load unpacked**, and select `dist/chromium/`.
+Chrome or Edge: open `chrome://extensions` or `edge://extensions`, enable **Developer mode**, choose **Load unpacked**, and select `dist/chromium/`.
 
-A Chrome development build needs one more setup step. The extension has not been published to the Chrome Web Store, so the ID assigned to a locally loaded copy is not in Motrix's built-in trust list. Without adding it, Motrix rejects the connection before it shows a pairing code.
+An unpacked Chrome or Edge development build may receive an ID outside Motrix's built-in trust list. If its ID is not already trusted, add it before pairing; otherwise Motrix rejects the connection before it shows a pairing code.
 
-1. Stay on `chrome://extensions`, find Motrix Extension, and copy the ID shown on its card.
+1. Stay on `chrome://extensions` or `edge://extensions`, find Motrix Extension, and copy the ID shown on its card.
 2. In Motrix, open **Settings → Integration → Browser extensions** and make sure **Send downloads from browser extensions** is enabled.
 3. Expand **Trusted extensions**, choose **Add extension**, paste the ID, select **Chrome / Edge**, and choose **Add**. The label is optional.
 4. Return to the extension, connect to Motrix again, and complete pairing when prompted.
 
-Only add the ID you copied from your browser's extension-management page. Chrome may assign a different ID if you move the unpacked build to another directory or install it on another computer. If that happens, remove the old entry from Motrix and add the new one.
+Only add the ID you copied from your browser's extension-management page. Chrome or Edge may assign a different ID if you move the unpacked build to another directory or install it on another computer. If that happens, remove the old entry from Motrix and add the new one.
 
 Firefox: open `about:debugging#/runtime/this-firefox`, choose **Load Temporary Add-on**, and select `dist/firefox/manifest.json`. Firefox removes temporary extensions when it restarts.
 
@@ -126,9 +139,9 @@ Remote Server permissions start at the narrowest scope. Unless you explicitly en
 
 ## Common questions
 
-### Why can't the Chrome development build connect to Motrix?
+### Why can't the Chrome or Edge development build connect to Motrix?
 
-Check that its extension ID appears under **Settings → Integration → Browser extensions → Trusted extensions** in Motrix. You can copy the ID from the Motrix Extension card on `chrome://extensions`. If you loaded the build from a different directory, Chrome may have assigned a new ID, so update the Motrix entry as well.
+Check that its extension ID appears under **Settings → Integration → Browser extensions → Trusted extensions** in Motrix. You can copy the ID from the Motrix Extension card on `chrome://extensions` or `edge://extensions`. If you loaded the build from a different directory, the browser may have assigned a new ID, so update the Motrix entry as well.
 
 ### Why can't the extension find Motrix on this computer?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,14 +19,27 @@
 
 你需要：
 
-- Chrome 120 或更高版本，或者 Firefox 142 或更高版本；
+- Chrome 120 或更高版本、当前版本的 Microsoft Edge，或者 Firefox 142 或更高版本；
 - 支持当前 MDXP / MBP1 协议的 Motrix App 或 Motrix Server；
 - 如果要连接本机 Motrix App，请先启动 Motrix，并确保它的浏览器连接组件已经正确安装。
 
 Firefox Android 通过 Motrix Server 连接。Android 不支持 Native Messaging，
 因此本机 Motrix App 后端只会在桌面浏览器中显示。
 
-目前还没有可供普通用户直接安装的商店版本或稳定安装包。想提前试用，需要从源码构建扩展；如果你只想安静地下载文件，我建议等第一个公开版本，这会少踩不少坑。
+## 安装
+
+先安装 [Motrix 2](https://motrix.app/zh/download?channel=beta)，再从浏览器商店安装扩展：
+
+- [Chrome Web Store](https://chromewebstore.google.com/detail/motrix-extension/lggbokfckofcgjndaboioakcmincinpo)
+- [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/motrix-extension/efcflljngohddnmfmebiamigoikmdfbf)
+
+商店版无需开启开发者模式，也无需手动添加受信任的扩展 ID。按下方[第一次连接](#第一次连接)完成配对，或参阅[浏览器扩展指南](https://motrix.app/zh/manual/browser-extension/)。
+
+Motrix AppImage 安装包目前不支持本机浏览器集成。在 Linux 上需要本机配对时，请使用 DEB 或 RPM 安装包。
+
+Firefox 商店版即将推出，目前可以按下方开发流程构建并临时加载。扩展暂不支持 YouTube 下载，面向商店的 Chrome/Edge 与 Firefox 构建均已移除占位用的 YouTube 适配器。
+
+## 手动加载开发版
 
 <details>
 <summary>从源码安装测试版</summary>
@@ -39,16 +52,16 @@ pnpm build:chromium
 pnpm build:firefox
 ```
 
-Chrome：打开 `chrome://extensions`，启用“开发者模式”，点击“加载已解压的扩展程序”，选择 `dist/chromium/`。
+Chrome 或 Edge：打开 `chrome://extensions` 或 `edge://extensions`，启用“开发者模式”，点击“加载已解压的扩展程序”，选择 `dist/chromium/`。
 
-Chrome 开发版还要登记一次扩展 ID。现在扩展尚未发布到 Chrome 应用商店，本地加载得到的 ID 不在 Motrix 的内置信任名单中；少了这一步，Motrix 会拒绝连接，配对码也不会出现。
+本地加载的 Chrome 或 Edge 开发版可能获得不在 Motrix 内置信任名单中的 ID。如果该 ID 尚未受信任，请先添加再配对；否则 Motrix 会拒绝连接，配对码也不会出现。
 
-1. 留在 `chrome://extensions`，找到 Motrix Extension，复制卡片上的 ID。
+1. 留在 `chrome://extensions` 或 `edge://extensions`，找到 Motrix Extension，复制卡片上的 ID。
 2. 打开 Motrix 的“设置 → 集成 → 浏览器扩展”，确认“用浏览器扩展发送下载到 Motrix”已经开启。
 3. 展开“受信任的扩展”，点击“添加扩展”，粘贴刚才复制的 ID，浏览器选择“Chrome / Edge”，然后点击“添加”。备注可以不填。
 4. 回到扩展，重新连接 Motrix，再按提示完成配对。
 
-只添加你刚刚从浏览器扩展管理页复制的 ID。如果换了电脑，或者从另一个目录重新加载开发版，Chrome 可能分配新的 ID；这时要在 Motrix 中移除旧记录，再添加新 ID。
+只添加你刚刚从浏览器扩展管理页复制的 ID。如果换了电脑，或者从另一个目录重新加载开发版，Chrome 或 Edge 可能分配新的 ID；这时要在 Motrix 中移除旧记录，再添加新 ID。
 
 Firefox：打开 `about:debugging#/runtime/this-firefox`，点击“临时载入附加组件”，选择 `dist/firefox/manifest.json`。临时扩展会在 Firefox 重启后被移除。
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@motrix/extension",
   "version": "0.1.7",
   "private": true,
-  "description": "Motrix browser extension (Chrome MV3 + Firefox MV3)",
+  "description": "Motrix browser extension for Chrome, Microsoft Edge, and Firefox (Manifest V3)",
   "type": "module",
   "packageManager": "pnpm@11.24.0",
   "engines": {

--- a/src/options/tabs/__tests__/HelpTab.test.tsx
+++ b/src/options/tabs/__tests__/HelpTab.test.tsx
@@ -50,7 +50,7 @@ describe('HelpTab', () => {
     expect(links.map((link) => link.getAttribute('href'))).toEqual(
       expect.arrayContaining([LINKS.issues, LINKS.docs])
     )
-    expect(LINKS.docs).toBe('https://motrix.app/manual/')
+    expect(LINKS.docs).toBe('https://motrix.app/manual/browser-extension/')
     expect(links.every((link) => link.getAttribute('role') === null)).toBe(true)
     expect(container.querySelector('.lucide-external-link')).toBeNull()
     expect(container.querySelectorAll('.lucide-chevron-right')).toHaveLength(2)

--- a/src/shared/links.ts
+++ b/src/shared/links.ts
@@ -3,6 +3,6 @@ export const LINKS = {
   website: 'https://motrix.app',
   repo: 'https://github.com/motrixapp/motrix-extension',
   issues: 'https://github.com/agalwood/Motrix/issues',
-  docs: 'https://motrix.app/manual/',
+  docs: 'https://motrix.app/manual/browser-extension/',
   license: 'https://github.com/agalwood/Motrix/blob/master/LICENSE',
 } as const


### PR DESCRIPTION
Motrix Extension is available on the Chrome Web Store and Microsoft Edge Add-ons, but the public READMEs still described it as unpublished. Add both official store links in English and Chinese, distinguish store installs from unpacked development builds, document the Firefox store status, and point Help to the browser-extension guide. The development section also provides the anchor linked from Motrix Settings and the website.

Validation: lint and import checks, TypeScript, all 2,002 tests (the five socket tests rerun with localhost access), Chrome/Edge store build verification, and Firefox build verification passed. Both installation guides document the current AppImage limitation. No extension version or release tag changes.
