### PR TITLE
docs: add the published firefox extension store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Send downloads from your browser to [Motrix](https://motrix.app), then check the
 I think of it as a bridge between the browser and Motrix. The browser is good at finding resources; Motrix is good at downloading them reliably. That division of labor is simple, and it feels right in daily use.
 
 > [!IMPORTANT]
-> Motrix Extension is available from the Chrome Web Store and Microsoft Edge Add-ons. YouTube downloads are not supported; store-facing Chrome/Edge and Firefox builds remove the placeholder YouTube adapter entirely.
+> Motrix Extension is available from the Chrome Web Store, Microsoft Edge Add-ons, and Firefox Add-ons. YouTube downloads are not supported; store-facing Chrome/Edge and Firefox builds remove the placeholder YouTube adapter entirely.
 
 ## What you can do
 
@@ -37,12 +37,11 @@ Install [Motrix 2](https://motrix.app/download?channel=beta), then add the exten
 
 - [Chrome Web Store](https://chromewebstore.google.com/detail/motrix-extension/lggbokfckofcgjndaboioakcmincinpo)
 - [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/motrix-extension/efcflljngohddnmfmebiamigoikmdfbf)
+- [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/motrix-extension/)
 
 Store installations do not require Developer mode or a manually added trusted extension ID. Follow [Connect for the first time](#connect-for-the-first-time) below to pair with Motrix, or read the [browser extension guide](https://motrix.app/manual/browser-extension/).
 
 Local browser integration is not currently available in the Motrix AppImage package. On Linux, use the DEB or RPM package for local pairing.
-
-The Firefox store release is coming soon. Use the development workflow below to build and temporarily load it.
 
 ## Manual browser workflow (development)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,12 +32,13 @@ Firefox Android 通过 Motrix Server 连接。Android 不支持 Native Messaging
 
 - [Chrome Web Store](https://chromewebstore.google.com/detail/motrix-extension/lggbokfckofcgjndaboioakcmincinpo)
 - [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/motrix-extension/efcflljngohddnmfmebiamigoikmdfbf)
+- [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/motrix-extension/)
 
 商店版无需开启开发者模式，也无需手动添加受信任的扩展 ID。按下方[第一次连接](#第一次连接)完成配对，或参阅[浏览器扩展指南](https://motrix.app/zh/manual/browser-extension/)。
 
 Motrix AppImage 安装包目前不支持本机浏览器集成。在 Linux 上需要本机配对时，请使用 DEB 或 RPM 安装包。
 
-Firefox 商店版即将推出，目前可以按下方开发流程构建并临时加载。扩展暂不支持 YouTube 下载，面向商店的 Chrome/Edge 与 Firefox 构建均已移除占位用的 YouTube 适配器。
+扩展暂不支持 YouTube 下载，面向商店的 Chrome/Edge 与 Firefox 构建均已移除占位用的 YouTube 适配器。
 
 ## 手动加载开发版
 


### PR DESCRIPTION
Motrix Extension is now available on Firefox Add-ons. Add its English store URL to both READMEs and replace the coming-soon guidance with normal store installation. Keep manual loading instructions for development builds.

Validation: `pnpm lint`, `pnpm typecheck`, and verification of the public Mozilla listing and extension ID.
