### PR TITLE
chore: release 0.1.9 / 发布 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motrix/extension",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "Motrix browser extension for Chrome, Microsoft Edge, and Firefox (Manifest V3)",
   "type": "module",


### PR DESCRIPTION
## 中文

将扩展版本从 0.1.8 升级至 0.1.9，准备发布已合并的 [PR #13](https://github.com/motrixapp/motrix-extension/pull/13)：连接自助诊断、开发安装与扩展 ID 白名单提示、统一滚动布局和 Motrix CopyButton。

浏览器 manifest 从 package.json 读取版本。合并后在 main 的发布提交上创建 v0.1.9 标签，由现有 GitHub Actions 流程运行质量检查、构建和产物校验并发布 Release。

验证：2,029 项测试通过；Biome、导入检查、TypeScript、Chrome/Edge Web Store 与 Firefox 构建、产物结构和 0.1.9 manifest 版本校验通过。

## English

Bump the extension from 0.1.8 to 0.1.9 to release the merged [PR #13](https://github.com/motrixapp/motrix-extension/pull/13): self-service connection diagnostics, development-install and extension ID allowlist guidance, a single scroll container, and the Motrix CopyButton.

Browser manifests derive their version from package.json. After merging, tag the release commit on main as v0.1.9; the existing GitHub Actions workflow runs quality checks, builds and verifies the artifacts, and publishes the release.

Validation: all 2,029 tests passed, along with Biome, import checks, TypeScript, Chrome/Edge Web Store and Firefox builds, artifact structure checks, and verification that both manifests use version 0.1.9.
