### PR TITLE
chore: 发布扩展 0.1.10 / release extension 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@motrix/extension",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "description": "Motrix browser extension for Chrome, Microsoft Edge, and Firefox (Manifest V3)",
   "type": "module",


### PR DESCRIPTION
## 中文

将扩展版本从 0.1.9 升至 0.1.10，发布已合并的配对排查提示（#15）：

- 本机连接失败时，提示手动打开 Motrix，阅读并确认首次启动条款，进入主界面后重试。
- 补充 Homebrew 用户改用官方 Release 并完成首次启动后恢复配对的反馈，附官方下载链接；不将安装来源写成已确认的故障原因。
- 提示覆盖全部 16 种语言，仅用于本机 Motrix 连接。

验证：静态检查、导入检查、TypeScript 检查、完整测试套件、Chrome/Edge 与 Firefox 构建和产物校验，以及 0.1.10 manifest 版本校验。

## English

Bump the extension from 0.1.9 to 0.1.10 to publish the merged pairing troubleshooting guidance (#15):

- Local connection failures explain how to launch Motrix manually, review and accept its first-launch terms if appropriate, and retry once the main window appears.
- Include a user-reported recovery path for Homebrew installations using official Releases and completed first-launch setup, with a download link. The installation source is not presented as a confirmed cause.
- These hints cover all 16 locales and apply only to local Motrix connections.

Validation: lint, import conventions, TypeScript, the full test suite, Chrome/Edge and Firefox builds with artifact checks, and manifest version verification for 0.1.10.
